### PR TITLE
Document multilingual UI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository contains a production-grade machine learning pipeline and modern
 - 🧠 **AI Analysis** - OpenAI-powered trading recommendations with retry logic and caching
 - ⚛️ **Modern React UI** - Real-time updates with color-coded indicators and dark/light theme toggle
 - 🌓 **Dark Mode Support** - Persistent theme toggle with smooth transitions
+- 🌐 **Multi-Language UI** - Switch between **English, German, Italian, and Spanish** via the header dropdown (preference saved)
 - 🔍 **Company Detail Sidebar** - Comprehensive stock information with country domicile
 - 💊 **Health Status Indicator** - Real-time system health monitoring with icon-based status display
 - 📋 **Health Check Modal** - Comprehensive system diagnostics overlay with performance metrics
@@ -106,6 +107,7 @@ cd frontend && npm run dev
    - Add both AAPL (stocks) and bitcoin (crypto) to the same watchlist
    - Get live prices, predictions, and investment insights for all assets
    - Toggle between stock and crypto search modes with visual indicators
+   - **Language selector** in the header to switch between English, German, Italian, and Spanish (saved to local preference)
 
 ### Training Your Model
 

--- a/docs/features/FRONTEND_COMPONENTS.md
+++ b/docs/features/FRONTEND_COMPONENTS.md
@@ -17,6 +17,7 @@ This document describes the React components in the Trading-Fun frontend applica
 - Stock rankings display with pagination
 - Company detail sidebar
 - Theme toggle (light/dark mode)
+- Simulation dashboard language dropdown (EN/DE/IT/ES) with persisted preference
 - Health status indicator integration
 - Error handling with user-friendly messages
 
@@ -28,6 +29,10 @@ This document describes the React components in the Trading-Fun frontend applica
 - `darkMode`: Theme preference (persisted to localStorage)
 - `showHealthPanel`: Controls health modal visibility
 - `healthStatus`: Current system health status
+
+**Localization:**
+- Strings are organized by language in `frontend/src/translations.js`.
+- The simulation dashboard stores the chosen language in `localStorage` (`app_language`) so subsequent visits reuse the same locale.
 
 **Health Indicator Implementation:**
 ```jsx

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Trading-Fun is a **production-grade** ML-powered stock market predictor with com
 - **ML Pipeline**: Feature engineering (RSI, SMA, MACD, Bollinger Bands, Momentum)
 - **FastAPI Backend**: Prediction, ranking, crypto analysis, AI insights
 - **React Frontend**: Modern UI with dark mode, accessibility (WCAG AA)
+- **Localization**: Built-in language selector with **English, German, Italian, Spanish** (preference persisted)
 - **Monitoring**: Prometheus metrics (20+), Grafana dashboards, Sentry error tracking
 - **Security**: 0 vulnerabilities, rate limiting (60 req/min), secret scanning
 - **Deployment**: 3 automated methods (GitHub Actions, CLI script, manual)
@@ -67,6 +68,11 @@ pytest
 # Deployment validation
 ./scripts/test_deployment.sh <production-url>
 ```
+
+### Localization
+
+- Switch the UI between **English, German, Italian, and Spanish** using the built-in language dropdown; your choice is saved in `localStorage` as `app_language` for future visits.
+- All translated strings live in `frontend/src/translations.js`; add a new language by duplicating a block and wiring the new key into the selector.
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary
- highlight the multilingual UI dropdown (EN/DE/IT/ES) in the README and main docs overview
- add localization guidance on how preferences are stored and where translations live
- note the language selector and persistence in the frontend components documentation

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334ef0a46883218fe6598e60bba067)