### PR TITLE
Fix invalid requirements comment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ redis==5.0.1  # For production caching (optional, fallback to in-memory)
 websockets==15.0.1  # Required by yfinance for live data features
 requests==2.32.5  # For HTTP calls (crypto API, etc.)
 prometheus-client==0.21.0  # For metrics collection and monitoring
-
 # Optional: xgboost & pyarrow may require system deps (libomp, cmake) on macOS. If installing on macOS, run
-# `brew install libomp cmake` or use a container with wheels available. If you prefer to avoid compilation, comment out xgboost and pyarrow.
+# `brew install libomp cmake` or use a container with wheels available. If you prefer to avoid compilation, comment out xgboost
+# and pyarrow.


### PR DESCRIPTION
## Summary
- comment the stray `and pyarrow.` line in requirements.txt so pip can parse the file
- unblock docker build by ensuring requirements are valid

## Testing
- Not run (environment lacks package download access)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69348f9233b48321a08319ec4907e898)