### PR TITLE
Fix trainer import path for CI

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -1,7 +1,15 @@
 """Trainer script that can be used by CI/CD or a scheduled job to retrain and save models."""
 
 import os
+import sys
+from pathlib import Path
 from datetime import datetime
+
+# Ensure repository root is on sys.path so imports work when running directly
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 from market_predictor.trading import build_dataset, train_model
 import mlflow
 


### PR DESCRIPTION
## Summary
- ensure the trainer script can import the project package when run directly by adding the repository root to `sys.path`

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693490d3cd608321b86c46c64970d8c9)