### PR TITLE
Handle missing frontend build artifacts in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /frontend
 COPY frontend/package*.json ./
 RUN npm ci || true
 COPY frontend/ ./
-RUN npm run build || echo "Frontend build skipped"
+RUN npm run build || (mkdir -p dist && echo "Frontend build skipped; created empty dist")
 
 FROM python:3.10-slim AS backend
 WORKDIR /app


### PR DESCRIPTION
## Summary
- create an empty frontend dist directory when the Vite build is skipped
- prevent Docker copy failure when frontend assets are unavailable

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934946404a0832190b684275672111d)