### PR TITLE
Fix malformed heading markup in SimulationDashboard info card

### DIFF
--- a/frontend/src/components/SimulationDashboard.jsx
+++ b/frontend/src/components/SimulationDashboard.jsx
@@ -321,7 +321,7 @@ function SimulationDashboard() {
           </div>
 
           <div className="info-card">
-            <h4>{t('features')}</h4>)}</h4>
+            <h4>{t('features')}</h4>
             <ul>
               <li>✓ {t('feature1')}</li>
               <li>✓ {t('feature2')}</li>


### PR DESCRIPTION
## Summary
- correct the SimulationDashboard features info card heading markup
- ensure the JSX structure closes tags properly to allow builds to succeed

## Testing
- bun run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693495e9f3e4832189f8f12c5167bb27)