### PR TITLE
Enhance simulation recommendations with pricing data

### DIFF
--- a/frontend/src/components/SimulationDashboard.jsx
+++ b/frontend/src/components/SimulationDashboard.jsx
@@ -210,19 +210,33 @@ function SimulationDashboard() {
   };
 
   const executeRecommendation = async (rec) => {
-    if (!confirm(`${rec.action} ${rec.ticker}?\nConfidence: ${(rec.confidence * 100).toFixed(1)}%\nReason: ${rec.reason}`)) {
+    const price = rec.price ?? rec.current_price ?? 0;
+    const quantity = rec.quantity ?? 10;
+
+    const confirmationMessage = [
+      `${rec.action} ${rec.ticker}?`,
+      `Confidence: ${(rec.confidence * 100).toFixed(1)}%`,
+      price ? `Price: $${price.toFixed(2)}` : null,
+      `Quantity: ${quantity}`,
+      `Reason: ${rec.reason}`
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    if (!confirm(confirmationMessage)) {
       return;
     }
 
-    // Get current price (simplified - in production, fetch real-time price)
-    const quantity = 10; // Default quantity
-    const price = 100; // TODO: Fetch real price
-
+    const tradePrice = price || tradeForm.price;
+    if (!tradePrice || tradePrice <= 0) {
+      setError(t('errorTrade') + ': ' + t('missingPrice'));
+      return;
+    }
     await executeTrade(
       rec.ticker,
       rec.action,
       quantity,
-      price,
+      tradePrice,
       rec.reason,
       rec.confidence
     );

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -79,6 +79,7 @@ export const translations = {
     errorRecommendations: 'Fehler beim Laden der Empfehlungen',
     errorTrade: 'Fehler beim Trade',
     errorAutoTrade: 'Auto-Trade Fehler',
+    missingPrice: 'Preisangaben fehlen',
     
     // Language
     language: 'Sprache',
@@ -162,6 +163,7 @@ export const translations = {
     errorRecommendations: 'Error loading recommendations',
     errorTrade: 'Error executing trade',
     errorAutoTrade: 'Auto-Trade error',
+    missingPrice: 'Missing price information',
     
     // Language
     language: 'Language',
@@ -245,6 +247,7 @@ export const translations = {
     errorRecommendations: 'Errore durante il caricamento delle raccomandazioni',
     errorTrade: 'Errore durante il trade',
     errorAutoTrade: 'Errore Auto-Trade',
+    missingPrice: 'Informazioni sul prezzo mancanti',
     
     // Language
     language: 'Lingua',
@@ -328,6 +331,7 @@ export const translations = {
     errorRecommendations: 'Error al cargar las recomendaciones',
     errorTrade: 'Error al ejecutar el trade',
     errorAutoTrade: 'Error Auto-Trade',
+    missingPrice: 'Falta información de precio',
     
     // Language
     language: 'Idioma',


### PR DESCRIPTION
## Summary
- include price- and quantity-aware recommendations from the simulation engine
- surface recommendation pricing/quantity in the simulation dashboard confirmation flow
- add missing translation strings for the new error message

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935495bf1948321b564981d3949ec64)