### PR TITLE
Add language selector and enhance simulation history insights

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,6 +52,7 @@ function AppContent() {
     const saved = localStorage.getItem('darkMode')
     return saved ? JSON.parse(saved) : false
   })
+  const [language, setLanguage] = useState(() => localStorage.getItem('app_language') || 'en')
 
   // Digital Assets / Crypto state
   const [portfolioView, setPortfolioView] = useState('stocks') // 'stocks', 'crypto', 'watchlists', 'simulation', or 'buy-opportunities'
@@ -82,6 +83,10 @@ function AppContent() {
     document.body.classList.toggle('dark-mode', darkMode)
     localStorage.setItem('darkMode', JSON.stringify(darkMode))
   }, [darkMode])
+
+  useEffect(() => {
+    localStorage.setItem('app_language', language)
+  }, [language])
 
   // Auto-load ranking on mount
   useEffect(() => {
@@ -338,14 +343,31 @@ function AppContent() {
       <a href="#main-content" className="skip-link">Skip to main content</a>
 
       <header className="header" role="banner">
-        <button
-          className="theme-toggle"
-          onClick={toggleDarkMode}
-          aria-label={`Switch to ${darkMode ? 'light' : 'dark'} mode`}
-          title={`Toggle ${darkMode ? 'light' : 'dark'} mode`}
-        >
-          {darkMode ? '☀️' : '🌙'}
-        </button>
+        <div className="header-actions" aria-label="Display settings">
+          <div className="language-control">
+            <label htmlFor="language-select" className="sr-only">Language</label>
+            <select
+              id="language-select"
+              value={language}
+              onChange={e => setLanguage(e.target.value)}
+              aria-label="Select application language"
+            >
+              <option value="de">🇩🇪 Deutsch</option>
+              <option value="it">🇮🇹 Italiano</option>
+              <option value="en">🇬🇧 English</option>
+              <option value="es">🇪🇸 Español</option>
+              <option value="fr">🇫🇷 Français</option>
+            </select>
+          </div>
+          <button
+            className="theme-toggle"
+            onClick={toggleDarkMode}
+            aria-label={`Switch to ${darkMode ? 'light' : 'dark'} mode`}
+            title={`Toggle ${darkMode ? 'light' : 'dark'} mode`}
+          >
+            {darkMode ? '☀️' : '🌙'}
+          </button>
+        </div>
         <button
           className={`health-indicator ${healthStatus}`}
           onClick={() => setShowHealthPanel(!showHealthPanel)}
@@ -595,7 +617,7 @@ function AppContent() {
 
       {/* Trading Simulation View */}
       {portfolioView === 'simulation' && (
-        <SimulationDashboard />
+        <SimulationDashboard language={language} onLanguageChange={setLanguage} />
       )}
 
       {/* Buy Opportunities View */}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -60,6 +60,44 @@ body.dark-mode .container {
   position: relative;
 }
 
+.header-actions {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.language-control select {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-weight: 600;
+  color: #1a202c;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.06);
+}
+
+body.dark-mode .language-control select {
+  background: rgba(26, 32, 44, 0.8);
+  color: #f7fafc;
+  border-color: #2d3748;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body.dark-mode .header {
   border-bottom: 2px solid #2e343d;
 }
@@ -92,9 +130,7 @@ body.dark-mode .header p {
 }
 
 .theme-toggle {
-  position: absolute;
-  top: 0;
-  right: 0;
+  position: relative;
   background: rgba(255, 255, 255, 0.2);
   border: 2px solid rgba(255, 255, 255, 0.3);
   color: white;

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -1,4 +1,4 @@
-// Multi-language support: DE, EN, IT, ES
+// Multi-language support: DE, EN, IT, ES, FR
 
 export const translations = {
   de: {
@@ -65,6 +65,10 @@ export const translations = {
     total: 'Gesamt',
     noTrades: 'Keine Trades vorhanden',
     noTradesHint: 'Starte Auto-Trade oder führe manuelle Trades aus',
+    positionAfter: 'Position nach Trade',
+    avgCostAfter: 'Ø Kosten (nach Trade)',
+    cashBalance: 'Kassenbestand',
+    cumulativePnl: 'Kum. P&L',
     
     // Messages
     simulationCreated: 'Simulation erstellt mit',
@@ -149,6 +153,10 @@ export const translations = {
     total: 'Total',
     noTrades: 'No trades available',
     noTradesHint: 'Start Auto-Trade or execute manual trades',
+    positionAfter: 'Position After Trade',
+    avgCostAfter: 'Avg Cost (Post-Trade)',
+    cashBalance: 'Cash Balance',
+    cumulativePnl: 'Cumulative P&L',
     
     // Messages
     simulationCreated: 'Simulation created with',
@@ -233,6 +241,10 @@ export const translations = {
     total: 'Totale',
     noTrades: 'Nessun trade disponibile',
     noTradesHint: 'Inizia Auto-Trade o esegui trade manuali',
+    positionAfter: 'Posizione dopo il trade',
+    avgCostAfter: 'Costo medio (post-trade)',
+    cashBalance: 'Saldo cassa',
+    cumulativePnl: 'P&L cumulativo',
     
     // Messages
     simulationCreated: 'Simulazione creata con',
@@ -317,6 +329,10 @@ export const translations = {
     total: 'Total',
     noTrades: 'No hay trades disponibles',
     noTradesHint: 'Inicia Auto-Trade o ejecuta trades manuales',
+    positionAfter: 'Posición después del trade',
+    avgCostAfter: 'Costo promedio (post-trade)',
+    cashBalance: 'Saldo de efectivo',
+    cumulativePnl: 'P&L acumulado',
     
     // Messages
     simulationCreated: 'Simulación creada con',
@@ -335,6 +351,94 @@ export const translations = {
     
     // Language
     language: 'Idioma',
+  },
+
+  fr: {
+    // Navigation & Tabs
+    overview: 'Vue d’ensemble',
+    recommendations: 'Recommandations IA',
+    trade: 'Transaction',
+    history: 'Historique',
+
+    // Simulation Start
+    startSimulation: 'Démarrer la simulation',
+    initialCapital: 'Capital initial',
+    creating: 'Création en cours...',
+    features: 'Fonctionnalités',
+    feature1: 'Recommandations d’achat/vente basées sur l’IA',
+    feature2: 'Gestion automatique du portefeuille',
+    feature3: 'Stratégies Stop-Loss & Take-Profit',
+    feature4: 'Suivi de performance & métriques',
+    feature5: 'Historique des trades & justifications',
+
+    // Metrics
+    portfolioValue: 'Valeur du portefeuille',
+    cash: 'Trésorerie',
+    positions: 'Positions',
+    winRate: 'Taux de réussite',
+
+    // Buttons
+    refresh: 'Actualiser',
+    reset: 'Réinitialiser la simulation',
+    loadRecommendations: 'Charger les recommandations',
+    autoTrade: 'Auto-Trade (Top 3)',
+    executeTrade: 'Exécuter la transaction',
+    loading: 'Chargement...',
+    executing: 'Exécution...',
+
+    // Overview Tab
+    holdings: 'Positions du portefeuille',
+    ticker: 'Ticker',
+    quantity: 'Quantité',
+    avgCost: 'Coût moyen',
+    currentPrice: 'Prix actuel',
+    value: 'Valeur',
+    noPositions: 'Aucune position disponible',
+    noPositionsHint: 'Créez des trades via les recommandations IA ou manuellement',
+
+    // Recommendations Tab
+    aiRecommendations: 'Recommandations de trading IA',
+    action: 'Action',
+    confidence: 'Confiance',
+    price: 'Prix',
+    reason: 'Raison',
+    execute: 'Exécuter',
+    noRecommendations: 'Aucune recommandation',
+    loadFirst: 'Cliquez sur "Charger les recommandations"',
+
+    // Trade Tab
+    manualTrade: 'Trade manuel',
+    symbol: 'Symbole',
+    enterSymbol: 'ex. AAPL',
+
+    // History Tab
+    tradeHistory: 'Historique des trades',
+    time: 'Heure',
+    total: 'Total',
+    noTrades: 'Aucun trade disponible',
+    noTradesHint: 'Lancez l’Auto-Trade ou exécutez des trades manuels',
+    positionAfter: 'Position après trade',
+    avgCostAfter: 'Coût moyen (post-trade)',
+    cashBalance: 'Solde de trésorerie',
+    cumulativePnl: 'P&L cumulatif',
+
+    // Messages
+    simulationCreated: 'Simulation créée avec',
+    tradesExecuted: 'trades exécutés',
+    noTradesRecommended: 'Aucune transaction recommandée',
+    tradeSuccess: 'Trade réussi',
+
+    // Errors
+    errorCreating: 'Erreur lors de la création de la simulation',
+    errorLoading: 'Erreur lors du chargement de la simulation',
+    errorPortfolio: 'Erreur lors du chargement du portefeuille',
+    errorRecommendations: 'Erreur lors du chargement des recommandations',
+    errorTrade: 'Erreur lors de la transaction',
+    errorAutoTrade: 'Erreur Auto-Trade',
+    missingPrice: 'Information de prix manquante',
+
+    // Language
+    language: 'Langue',
   }
 };
 


### PR DESCRIPTION
## Summary
- add a global language selector beside the theme toggle with persisted preference and refreshed header styling
- optimize simulation dashboard data fetching and trade history calculations for better performance and richer trade evolution details
- expand translations with French support and new labels for enhanced trade history tracking

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693550da76d0832192c655a91c4b1ca5)