### PR TITLE
Refresh documentation to match current beta

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,10 +6,10 @@ import os
 import sys
 
 # -- Project information -----------------------------------------------------
-project = 'Trading-Fun ML'
-copyright = '2025, KG90-EG'
-author = 'KG90-EG'
-release = '1.0.0'
+project = 'POC-MarketPredictor-ML'
+copyright = '2025, POC-MarketPredictor-ML contributors'
+author = 'POC-MarketPredictor-ML contributors'
+release = '0.9.0'
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/docs/getting-started/TRAINING_GUIDE.md
+++ b/docs/getting-started/TRAINING_GUIDE.md
@@ -2,300 +2,78 @@
 
 ## Overview
 
-Your ML model predicts stock movements based on technical indicators. Training it with more data and your watchlist stocks makes it **personalized to your investment strategy**.
+Use the training utilities in this repository to build and compare models that power the ranking and simulation flows. The scripts rely on the same feature pipeline used by the backend so the artifacts are immediately usable.
 
-## 🚀 Quick Start
-
-### 1. Train a New Model (5 minutes)
+## Setup
 
 ```bash
-# Activate your environment
-cd /Users/kevingarcia/Documents/POC-MarketPredictor-ML
+python -m venv .venv
 source .venv/bin/activate
+pip install -r requirements.txt
+```
 
-# Run training with default stocks
+Optional settings:
+- `MLFLOW_TRACKING_URI` to change where runs are logged (defaults to `file:./mlruns`).
+- `S3_BUCKET` to upload trained or promoted models after creation.
+
+## 🚀 Train a Model
+
+Train with the default tickers from the repository root:
+
+```bash
 python training/trainer.py
 ```
 
-This will:
+This downloads data, computes indicators, trains a Random Forest model, logs metrics to MLflow, and saves an artifact to `models/model_<timestamp>.bin`.
 
-- Download 2 years of historical data
-- Calculate technical indicators (RSI, MACD, Bollinger Bands, etc.)
-- Train a Random Forest model
-- Save to `models/model_YYYYMMDD_HHMMSS.bin`
-- Track metrics with MLflow
+### Train with Your Watchlist
 
-### 2. Train with YOUR Watchlist Stocks
+If you already have watchlists saved, reuse them for training:
 
 ```bash
-# Train with your favorite stocks
 python scripts/train_watchlist.py
 ```
 
-This will automatically train on ALL stocks in your watchlists!
+The script will build a dataset from your watchlist tickers before training.
 
-### 3. Evaluate and Deploy
+## ✅ Evaluate and Promote
+
+Compare a newly trained model against the current production model and promote it if it performs better:
 
 ```bash
-# Compare new model vs current production model
-python training/evaluate_and_promote.py
-
-# If better, it will automatically promote to prod_model.bin
+python training/evaluate_and_promote.py \
+  --new-model models/model_<timestamp>.bin \
+  --prod-model models/prod_model.bin \
+  --tickers AAPL,MSFT,NVDA
 ```
 
-## 📊 Training Options
+The promotion step copies the better model to `models/prod_model.bin` and, when configured, uploads it to S3.
 
-### Basic Training
+## ⚙️ Training Options
 
 ```python
 from market_predictor.trading import build_dataset, train_model
 
-# Build dataset
-tickers = ["AAPL", "MSFT", "GOOGL", "UBS"]
-data = build_dataset(tickers, period="2y")
+# Build a dataset for custom tickers and history
+symbols = ["AAPL", "MSFT", "GOOGL", "UBS"]
+data = build_dataset(symbols, period="2y")
 
-# Train model
+# Try different model types or hyperparameters
 model, metrics = train_model(data, model_type="rf")
-print(f"Accuracy: {metrics['accuracy']:.2%}")
-```
-
-### Advanced Training Options
-
-```python
-# 1. Different model types
-train_model(data, model_type="rf")      # Random Forest (default, best)
-train_model(data, model_type="xgb")     # XGBoost (faster)
-train_model(data, model_type="lgbm")    # LightGBM (memory efficient)
-
-# 2. Custom parameters
-train_model(data,
+model, metrics = train_model(data, model_type="xgb")
+model, metrics = train_model(
+    data,
     model_type="rf",
-    n_estimators=200,      # More trees = better but slower
-    max_depth=20,          # Deeper = more complex
-    min_samples_split=5    # Regularization
+    n_estimators=200,
+    max_depth=20,
+    min_samples_split=5,
 )
-
-# 3. More data
-data = build_dataset(tickers, period="5y")  # 5 years of data
 ```
 
-## 🎯 What Gets Trained?
+## 🔄 When to Retrain
 
-The model learns from these **technical indicators**:
+- Weekly or after major market events to keep signals fresh.
+- When watchlists change materially.
+- After backend feature changes that modify the dataset schema.
 
-1. **Price Features**
-   - Open, High, Low, Close, Volume
-   - Price changes and returns
-
-2. **Technical Indicators**
-   - **RSI** (Relative Strength Index) - Overbought/oversold
-   - **MACD** - Trend momentum
-   - **Bollinger Bands** - Volatility
-   - **SMA** (Simple Moving Averages) - 20, 50, 200 day
-   - **Momentum** - Price acceleration
-
-3. **Target Variable**
-   - Binary: Will price go up or down in next 90 days?
-
-## 📈 Training Workflow
-
-```
-┌─────────────────┐
-│ 1. Fetch Data   │ ← Download historical prices
-│    (2-5 years)  │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 2. Calculate    │ ← Compute RSI, MACD, etc.
-│    Indicators   │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 3. Create       │ ← Label: up/down in 90 days
-│    Labels       │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 4. Train Model  │ ← Random Forest learns patterns
-│    (ML Training)│
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 5. Evaluate     │ ← Test accuracy, precision, recall
-│    Performance  │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ 6. Deploy       │ ← Replace prod_model.bin if better
-└─────────────────┘
-```
-
-## 🔄 Retraining Schedule
-
-### Recommended Schedule
-
-1. **Weekly** - Quick retrain with recent data
-2. **Monthly** - Full retrain with expanded tickers
-3. **After major market events** - Immediate retrain
-
-### Automated Training (CI/CD)
-
-Already configured in `.github/workflows/retrain.yml`:
-
-- Runs every Monday at 2 AM
-- Trains on expanded stock list
-- Auto-deploys if accuracy improves
-
-## 📊 Monitoring Training
-
-### View Training History
-
-```bash
-# Start MLflow UI
-mlflow ui
-
-# Open browser to http://localhost:5000
-# View all training runs, compare metrics
-```
-
-### Check Model Performance
-
-```python
-from market_predictor.trading import train_model
-import joblib
-
-# Load your model
-model = joblib.load('models/prod_model.bin')
-
-# Predict on new data
-from market_predictor.trading import compute_features
-features = compute_features(df)
-predictions = model.predict(features)
-probabilities = model.predict_proba(features)
-```
-
-## 🎓 Training Tips
-
-### 1. **More Stocks = Better Model**
-
-Add diverse stocks to your watchlist:
-
-- Tech: AAPL, MSFT, GOOGL
-- Finance: JPM, GS, UBS
-- Energy: XOM, CVX
-- Healthcare: JNJ, PFE
-
-### 2. **More History = Better Predictions**
-
-```python
-# Good: 2 years
-data = build_dataset(tickers, period="2y")
-
-# Better: 5 years
-data = build_dataset(tickers, period="5y")
-
-# Best: Max available
-data = build_dataset(tickers, period="max")
-```
-
-### 3. **Regular Retraining**
-
-Markets change! Retrain monthly to adapt to:
-
-- New market conditions
-- Changing volatility
-- Sector rotation
-- Economic cycles
-
-## 🐛 Troubleshooting
-
-### "Dataset is empty"
-
-**Fix**: Some tickers don't have enough history. Use period="5y" or add more tickers.
-
-### "Training failed - not enough samples"
-
-**Fix**: After calculating indicators and forward-looking labels, some rows are dropped. Add more tickers or longer period.
-
-### "Model accuracy < 0.55"
-
-**Fix**: This is expected! Stock prediction is hard. Anything > 0.55 is valuable for trading.
-
-### "Out of memory"
-
-**Fix**: Use fewer tickers, shorter period, or model_type="lgbm"
-
-## 🚀 Advanced: Custom Training Script
-
-Create `scripts/train_watchlist.py`:
-
-```python
-#!/usr/bin/env python3
-"""Train model on all stocks from all watchlists."""
-
-import sys
-sys.path.insert(0, '.')
-
-from market_predictor.database import WatchlistDB
-from market_predictor.trading import build_dataset, train_model
-from datetime import datetime
-import os
-
-def main():
-    # Get all watchlists
-    watchlists = WatchlistDB.get_user_watchlists('default_user')
-
-    # Collect all unique tickers
-    all_tickers = set()
-    for wl in watchlists:
-        tickers = WatchlistDB.get_watchlist_tickers(wl['id'], 'default_user')
-        all_tickers.update(tickers)
-
-    print(f"Training on {len(all_tickers)} stocks from your watchlists:")
-    print(", ".join(sorted(all_tickers)))
-
-    # Build dataset
-    data = build_dataset(list(all_tickers), period="2y")
-
-    if data.empty:
-        print("ERROR: No data available")
-        return
-
-    print(f"Dataset shape: {data.shape}")
-
-    # Train
-    model_path = f"models/watchlist_model_{datetime.now().strftime('%Y%m%d_%H%M%S')}.bin"
-    os.makedirs("models", exist_ok=True)
-
-    model, metrics = train_model(data, model_type="rf", save_path=model_path)
-
-    print(f"✓ Model trained!")
-    print(f"  Accuracy: {metrics['accuracy']:.2%}")
-    print(f"  Precision: {metrics['precision']:.2%}")
-    print(f"  Saved to: {model_path}")
-
-    # Promote to production if accuracy > 0.55
-    if metrics['accuracy'] > 0.55:
-        import shutil
-        shutil.copy(model_path, 'models/prod_model.bin')
-        print(f"✓ Promoted to production!")
-
-if __name__ == '__main__':
-    main()
-```
-
-## 📚 Next Steps
-
-1. **Run your first training**: `python training/trainer.py`
-2. **Check MLflow UI**: `mlflow ui` (view at <http://localhost:5000>)
-3. **Set up automated retraining**: Already configured in GitHub Actions!
-4. **Monitor drift**: `python training/drift_check.py` weekly
-
----
-
-**Pro Tip**: The more you use the app and add stocks to your watchlists, the better the model becomes for YOUR investment style! 🎯💰
+Keep the `models/` directory versioned so you can revert to a stable artifact if needed.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,12 +1,12 @@
 # Getting Started
 
-Welcome to Trading-Fun ML! This section will help you get up and running quickly.
+Welcome to POC-MarketPredictor-ML. Use this guide to set up the project quickly and find the right docs for deeper dives.
 
 ## What You'll Learn
 
 - How to install and configure the application
-- Running your first predictions
-- Understanding the UI and features
+- Running your first predictions and simulations
+- Where the UI and backend live
 - Basic configuration and customization
 
 ## Prerequisites
@@ -16,15 +16,33 @@ Welcome to Trading-Fun ML! This section will help you get up and running quickly
 - **Git** (for cloning the repository)
 - **Docker** (optional, for containerized deployment)
 
+## Quick Start
+
+From the repository root:
+
+```bash
+# Backend
+pip install -r requirements.txt
+uvicorn market_predictor.server:app --reload
+
+# Frontend (new terminal)
+cd frontend
+npm install
+npm run dev
+```
+
+Open <http://localhost:5173> to use the UI. See the [README](../../README.md) for more context on the flows and endpoints.
+
 ## Quick Navigation
 
-- **[Quick Start](quick-start.md)** - Get running in 5 minutes
-- **[Installation](installation.md)** - Detailed installation guide
-- **[First Steps](first-steps.md)** - Your first predictions
+- **[Model Training Guide](TRAINING_GUIDE.md)** - Train and evaluate models from the repository
+- **[Architecture Spec](../architecture/SPECIFICATION.md)** - System overview and module map
+- **[Deployment Guide](../deployment/DEPLOYMENT_GUIDE.md)** - Options for hosting the stack
+- **[Simulation API](../api/simulation.md)** - Reference for the current simulation endpoints
 
 ## Next Steps
 
 Once you're set up, explore:
-- [Production Features](../features/production-features.md)
-- [API Documentation](../api/endpoints.md)
-- [Deployment Options](../deployment/index.md)
+- [Production Features](../features/PRODUCTION_FEATURES.md)
+- [Project Backlog](../project/backlog.md)
+- [Operations Guides](../operations/READTHEDOCS_SETUP.md)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,169 +1,102 @@
-# Trading-Fun ML Documentation
+# POC-MarketPredictor-ML Documentation
 
-[![Production Ready](https://img.shields.io/badge/Production-Ready-brightgreen)](../PRODUCTION_READY.md)
-[![Security](https://img.shields.io/badge/Vulnerabilities-0-brightgreen)](../scripts/security_check.sh)
-[![Tests](https://img.shields.io/badge/Tests-50%2B%20Passing-brightgreen)](../tests/)
+A FastAPI + React proof of concept for ranking equities/crypto, simulating trades, and iterating on ML models. The project is in **beta**: core flows work, and documentation and tests are being hardened.
 
-**Production-grade ML-powered stock market predictor with automated deployment, security hardening, and comprehensive monitoring.**
+Use this page as the entry point to the rest of the docs and the Sphinx navigation tree.
 
-**Status**: ✅ Production Ready (98% Complete) | [Deploy Now](../PRODUCTION_READY.md)
+## Project Snapshot
+
+- Backend + frontend aligned at **v0.9.0** with simulation endpoints available.
+- SQLite-backed persistence for simulations and watchlists (PostgreSQL migration planned).
+- Documentation index and backlog live in this repository—keep them in sync with code changes.
+
+## Quick Links
+
+- [Repository README](../README.md)
+- [Documentation index (markdown)](index.md)
+- [Project backlog](project/backlog.md)
+- [Simulation API reference](api/simulation.md)
+- [Deployment guide](deployment/DEPLOYMENT_GUIDE.md)
 
 ---
 
-## 📚 Documentation Structure
+```{toctree}
+:maxdepth: 2
+:caption: Overview
+
+index
+project/backlog
+```
 
 ```{toctree}
 :maxdepth: 2
 :caption: Getting Started
 
 getting-started/index
-getting-started/quick-start
-getting-started/installation
-getting-started/first-steps
+getting-started/TRAINING_GUIDE
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Architecture & Decisions
+
+architecture/SPECIFICATION
+architecture/ADR-001-architecture-overview
+architecture/ADR-002-model-training-strategy
+architecture/ADR-003-caching-strategy
 ```
 
 ```{toctree}
 :maxdepth: 2
 :caption: Deployment
 
-deployment/index
-deployment/production-ready
-deployment/automated-deployment
-deployment/backend-deployment
-deployment/frontend-deployment
+deployment/DEPLOYMENT_GUIDE
+deployment/DEPLOYMENT
+deployment/PRODUCTION_DEPLOYMENT
+deployment/BACKEND_DEPLOYMENT
+deployment/FRONTEND_DEPLOYMENT
+deployment/AUTOMATED_DEPLOYMENT
+deployment/PRODUCTION_READY
 ```
 
 ```{toctree}
 :maxdepth: 2
-:caption: Architecture & Design
+:caption: Features & Flows
 
-architecture/index
-architecture/adr-001-architecture-overview
-architecture/adr-002-model-training-strategy
-architecture/adr-003-caching-strategy
+features/PHASE_1_SUMMARY
+features/PHASE1_WATCHLISTS_SUMMARY
+features/BUY_SELL_OPPORTUNITIES
+features/FRONTEND_COMPONENTS
+features/ALERTS
+features/PRODUCTION_FEATURES
 ```
 
 ```{toctree}
 :maxdepth: 2
-:caption: Features & Usage
+:caption: API & Operations
 
-features/index
-features/production-features
-features/frontend-components
-features/cryptocurrency-portfolio
-features/ai-analysis
-```
-
-```{toctree}
-:maxdepth: 2
-:caption: Operations & Monitoring
-
-operations/index
-operations/performance-monitoring
-operations/security
-operations/testing
-operations/troubleshooting
-```
-
-```{toctree}
-:maxdepth: 2
-:caption: Development
-
-development/index
-development/contributing
-development/code-quality
-development/testing-guide
-development/accessibility
+api/simulation
+operations/PERFORMANCE_MONITORING
+operations/GITHUB_SECURITY_SETUP
+operations/GITHUB_SECRETS
+operations/READTHEDOCS_SETUP
 ```
 
 ```{toctree}
 :maxdepth: 1
-:caption: API Reference
+:caption: History
 
-api/index
-api/endpoints
-api/models
-api/websockets
-```
-
-```{toctree}
-:maxdepth: 1
-:caption: Historical
-
-history/index
-history/implementation-summary
-history/architecture-review
-history/improvements
+history/README
+history/IMPLEMENTATION_SUMMARY
+history/ARCHITECTURE_REVIEW
+history/IMPROVEMENTS
+history/PR_DESC_DEV_TO_MAIN
+history/PHASE_2_IMPROVEMENTS
+history/REORGANIZATION_PLAN
+history/REORGANIZATION_COMPLETE
+history/SESSION_SUMMARY_2025_12_02
 ```
 
 ---
 
-## 🚀 Quick Links
-
-- **[Production Ready Guide](../PRODUCTION_READY.md)** - Deploy in 10 minutes
-- **[API Documentation](http://localhost:8000/docs)** - Interactive Swagger UI
-- **[GitHub Repository](https://github.com/KG90-EG/POC-MarketPredictor-ML)** - Source code
-- **[Contributing Guide](development/CONTRIBUTING.md)** - How to contribute
-
----
-
-## 🎯 Project Overview
-
-### What is Trading-Fun ML?
-
-A production-grade machine learning application that provides:
-
-- **ML-Powered Predictions**: XGBoost models with 75%+ accuracy
-- **Multi-Market Support**: US, Switzerland, Germany, UK, France, Japan, Canada
-- **Cryptocurrency Portfolio**: Top crypto assets with momentum scoring
-- **AI Analysis**: OpenAI-powered trading recommendations
-- **Real-time Data**: Live prices, volume, market cap via yfinance
-- **Modern UI**: React 18 with dark mode, accessibility (WCAG AA)
-- **Production Monitoring**: Prometheus + Grafana with 20+ metrics
-- **Security Hardened**: 0 vulnerabilities, rate limiting, secret scanning
-- **Automated Deployment**: 3 methods (GitHub Actions, CLI, manual)
-
-### Key Features
-
-- ✅ **50+ Automated Tests** (75%+ coverage)
-- ✅ **0 Security Vulnerabilities** (CVE-2025-8869 fixed)
-- ✅ **Rate Limiting** (60 req/min with token bucket)
-- ✅ **Caching** (Multi-layer TTL: stock 5min, crypto 2min, AI 30min)
-- ✅ **CI/CD Pipeline** (GitHub Actions with security checks)
-- ✅ **Comprehensive Docs** (2000+ lines)
-- ✅ **WCAG AA Compliant** (95% accessibility)
-
----
-
-## 📊 Project Status
-
-**Version**: 1.0.0
-**Status**: Production Ready
-**Completion**: 98%
-**Last Updated**: December 2, 2025
-
-### Completed
-- ✅ Full-stack ML application (FastAPI + React)
-- ✅ 3 automated deployment methods
-- ✅ Security hardening (0 vulnerabilities)
-- ✅ Production monitoring setup
-- ✅ Comprehensive documentation
-
-### Roadmap
-- 🎯 A/B model testing & rollout
-- 📦 Cloud artifact storage (S3/GCS)
-- 🤖 Enhanced AI analysis features
-- 🧪 E2E testing (Playwright/Cypress)
-
----
-
-## 🆘 Need Help?
-
-- **Issues**: [GitHub Issues](https://github.com/KG90-EG/POC-MarketPredictor-ML/issues)
-- **Security**: [Security Policy](https://github.com/KG90-EG/POC-MarketPredictor-ML/security)
-- **Contributing**: [Contributing Guide](development/CONTRIBUTING.md)
-- **Deployment**: [Production Ready Guide](../PRODUCTION_READY.md)
-
----
-
-*Generated with [Sphinx](https://www.sphinx-doc.org/) | Theme: [Read the Docs](https://sphinx-rtd-theme.readthedocs.io/)*
+Need help? File an issue or start a discussion in the repository.


### PR DESCRIPTION
## Summary
- align Sphinx configuration with the POC-MarketPredictor-ML branding and release level
- rewrite documentation landing page to reflect the current beta scope and valid navigation
- streamline getting started and training guides with accurate commands and links

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935567f70008321bcee41f03edc5a9e)