### PR TITLE
Update backend entrypoints to market_predictor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY --from=frontend /frontend/dist /app/frontend/dist
 USER app
 ENV PROD_MODEL_PATH=/app/models/prod_model.bin
 EXPOSE 8000
-CMD ["uvicorn", "trading_fun.server:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "market_predictor.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,7 @@
         <h2>🔧 Quick Start</h2>
         <pre><code># Backend
 pip install -r requirements.txt
-uvicorn trading_fun.server:app --reload
+uvicorn market_predictor.server:app --reload
 
 # Frontend (new terminal)
 cd frontend && npm install && npm run dev</code></pre>

--- a/docs/project/QUICK_FIX.md
+++ b/docs/project/QUICK_FIX.md
@@ -45,7 +45,7 @@ sleep 2
 
 # 2. Backend starten
 cd /Users/kevingarcia/Documents/POC-MarketPredictor-ML
-.venv/bin/python -m uvicorn trading_fun.server:app --host 0.0.0.0 --port 8000 --reload &
+.venv/bin/python -m uvicorn market_predictor.server:app --host 0.0.0.0 --port 8000 --reload &
 
 # 3. Frontend neu bauen und starten
 cd frontend

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,7 +32,7 @@ norecursedirs = .git .tox dist build *.egg .venv .archive_old node_modules front
 
 # Coverage options (if using pytest-cov)
 # Uncomment to enable coverage reporting
-# addopts = --cov=trading_fun --cov-report=html --cov-report=term
+# addopts = --cov=market_predictor --cov-report=html --cov-report=term
 
 # Timeout for tests (requires pytest-timeout)
 # timeout = 300

--- a/start_servers.sh
+++ b/start_servers.sh
@@ -15,7 +15,7 @@ sleep 2
 
 echo "🚀 Starting backend on port $BACKEND_PORT..."
 cd "$PROJECT_DIR"
-.venv/bin/python -m uvicorn trading_fun.server:app --host 0.0.0.0 --port $BACKEND_PORT --reload > /tmp/backend.log 2>&1 &
+.venv/bin/python -m uvicorn market_predictor.server:app --host 0.0.0.0 --port $BACKEND_PORT --reload > /tmp/backend.log 2>&1 &
 BACKEND_PID=$!
 
 echo "🚀 Starting frontend on port $FRONTEND_PORT..."


### PR DESCRIPTION
## Summary
- update Docker and local start script to point uvicorn at `market_predictor.server:app`
- align quick start and troubleshooting docs with the new backend module
- refresh pytest coverage comment to match the updated package name

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693558d299788321a8f903c759a333b1)