### PR TITLE
Make start_servers script portable

### DIFF
--- a/start_servers.sh
+++ b/start_servers.sh
@@ -2,11 +2,17 @@
 # Quick Server Restart Script
 # Usage: ./start_servers.sh
 
-set -e
+set -euo pipefail
 
-PROJECT_DIR="/Users/kevingarcia/Documents/POC-MarketPredictor-ML"
-BACKEND_PORT=8000
-FRONTEND_PORT=5174
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
+BACKEND_PORT="${BACKEND_PORT:-8000}"
+FRONTEND_PORT="${FRONTEND_PORT:-5173}"
+
+PYTHON_CMD="python"
+if [ -x "$PROJECT_DIR/.venv/bin/python" ]; then
+  PYTHON_CMD="$PROJECT_DIR/.venv/bin/python"
+fi
 
 echo "🔄 Stopping existing servers..."
 pkill -9 -f "uvicorn" 2>/dev/null || true
@@ -15,12 +21,12 @@ sleep 2
 
 echo "🚀 Starting backend on port $BACKEND_PORT..."
 cd "$PROJECT_DIR"
-.venv/bin/python -m uvicorn market_predictor.server:app --host 0.0.0.0 --port $BACKEND_PORT --reload > /tmp/backend.log 2>&1 &
+"$PYTHON_CMD" -m uvicorn market_predictor.server:app --host 0.0.0.0 --port "$BACKEND_PORT" --reload > /tmp/backend.log 2>&1 &
 BACKEND_PID=$!
 
 echo "🚀 Starting frontend on port $FRONTEND_PORT..."
 cd "$PROJECT_DIR/frontend"
-npm run dev > /tmp/frontend.log 2>&1 &
+npm run dev -- --host 0.0.0.0 --port "$FRONTEND_PORT" > /tmp/frontend.log 2>&1 &
 FRONTEND_PID=$!
 
 sleep 5


### PR DESCRIPTION
## Summary
- update the start_servers helper to use the current repository path and optional PROJECT_DIR override
- select the available python interpreter and bind backend/frontend to 0.0.0.0 with configurable ports
- keep startup messaging and logging while ensuring background processes are relaunched cleanly

## Testing
- ./start_servers.sh
- curl -s http://localhost:8000/health
- curl -I http://localhost:5173


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69356304b8d08321814b18ad024a0279)